### PR TITLE
ci: fix project name in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,7 @@ source scripts/release_helpers.sh
 
 # Required Variables
 readonly org_name=lacework
-readonly project_name=terraform-<PROVIDER>-<NAME>
+readonly project_name=terraform-aws-config-controltower
 readonly git_user="Lacework Inc."
 readonly git_email="tech-ally@lacework.net"
 readonly required_files_for_release=(


### PR DESCRIPTION
## Summary

Project name was missing and causing errors in github workflows

## Issue

https://lacework.atlassian.net/browse/GROW-2760